### PR TITLE
blink LED, if no microSD card inserted & sample rate calculation corrected

### DIFF
--- a/I2S_32.h
+++ b/I2S_32.h
@@ -210,6 +210,7 @@ void I2S_32::update(void)
 // MCLK needs to be 48e6 / 1088 * 256 = 11.29411765 MHz -> 44.117647 kHz sample rate
 //
 #if F_CPU == 96000000 || F_CPU == 48000000 || F_CPU == 24000000
+//#if F_CPU == 96000000 || F_CPU == 24000000
   // PLL is at 96 MHz in these modes
   #define MCLK_MULT 2
   #define MCLK_DIV  17

--- a/audio_logger_if.h
+++ b/audio_logger_if.h
@@ -229,7 +229,20 @@ char * wavHeader(uint32_t fileSize)
 //____________________________ FS Interface implementation______________________
 void c_uSD::init()
 {
-  if (!sd.begin(SD_CONFIG)) sd.errorHalt("sd.begin failed");
+  if (!sd.begin(SD_CONFIG))
+  {
+//    sd.errorHalt("sd.begin failed");
+    while(1)
+    {
+      // blink code suggests insertion of an SD card
+            pinMode(13,OUTPUT);
+            digitalWriteFast(13,HIGH);
+            delay(200);
+            digitalWriteFast(13,LOW);
+            delay(200);
+    }
+  }
+
   // Set Time callback
   FsDateTime::callback = dateTime;
   //

--- a/audio_mods.h
+++ b/audio_mods.h
@@ -123,7 +123,7 @@ void ADC_modification(uint32_t fsamp, uint16_t diff)
   PDB0_SC = PDB_CONFIG | PDB_SC_LDOK;
 }
 
-// ********************************************** following is to change I2S samling rates ********************
+// ********************************************** following is to change I2S sampling rates ********************
 // attempt to generate dividers programmatically
 // always better to check
 void I2S_dividers(uint32_t *iscl, uint32_t fsamp, uint32_t nbits)
@@ -131,7 +131,8 @@ void I2S_dividers(uint32_t *iscl, uint32_t fsamp, uint32_t nbits)
     int64_t i1 = 1;
     int64_t i2 = 1;
     int64_t i3 = iscl[2]+1;
-    float A=F_CPU/2.0f/i3/((float)nbits*fsamp);
+//    float A=F_CPU/2.0f/i3/((float)nbits*fsamp);
+    float A=F_PLL/2.0f/i3/((float)nbits*fsamp);
     float mn=1.0; 
     for(int ii=1;ii<=256;ii++) 
     { float xx;

--- a/config.h
+++ b/config.h
@@ -46,7 +46,7 @@
 #define _I2S_TYMPAN     7 // I2S (16 bit tympan stereo audio audio) for use the tympan board
 #define _I2S_TDM        8 // I2S (8 channel TDM) // only first 5 channels are used (modify myAcq.h if less or more channels)
 
-#define ACQ   _I2S_TDM  // selected acquisition interface  //<<<======>>>
+#define ACQ   _I2S_32_MONO  // selected acquisition interface  //<<<======>>>
 
 // For ADC SE pins can be changed
 #if ACQ == _ADC_0


### PR DESCRIPTION
* blinking LED seems practical in the field
* sample rate calculation was off by a factor of 2 when using F_CPU of 48MHz [with 96MHz, it was correct]
--> not sure wether this is correct, I simply exchanged F_CPU with F_PLL in the calculation of the sample rate (because both F_CPUs, 48 & 96MHz, use F_PLL of 96MHz)